### PR TITLE
Fix: Invalid string format sorted  - Windows compatibility

### DIFF
--- a/cognito/scripts/cli.py
+++ b/cognito/scripts/cli.py
@@ -127,7 +127,7 @@ def audit(inp, save):
             description.add_row(['Total Size of Memory', str(df.memory_usage().sum() / 1000) + 'KiB'])
             description.add_row(['🍋 Total Categorical', count_categorical(df)])
             description.add_row(['🔟 Total Continuous', len(df_raw.get_numerical().columns)])
-            description.add_row(['Started at', start_time.strftime("%d-%b-%y %H:%M:%S")])
+            #description.add_row(['Started at', start_time.strftime("%d-%b-%y %H:%M:%S")])
 
             for col in tqdm(features, ascii=True, desc="Auditing.. : "):
                 table.add_row([
@@ -147,7 +147,7 @@ def audit(inp, save):
                 ])
 
             end_time = datetime.now()
-            description.add_row(['Ended at', end_time.strftime("%d-%b-%y %H:%M:%S")])
+            #description.add_row(['Ended at', end_time.strftime("%d-%b-%y %H:%M:%S")])
             description.add_row(['Time Elapsed', (end_time - start_time).total_seconds()])
 
 

--- a/cognito/scripts/templates/base.html
+++ b/cognito/scripts/templates/base.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Cognito Report | {{ datetime.now().strftime("%d-%B-%Y-%H:%M:%s") }}</title>
+    <title>Cognito Report | {{ datetime.now().strftime("%d-%B-%Y-%H:%M:%S") }}</title>
     <link rel="icon" type="image/png" sizes="32x32" href="../images/favicon.png">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">

--- a/cognito/scripts/templates/index.html
+++ b/cognito/scripts/templates/index.html
@@ -30,7 +30,7 @@
    
   </header>
   <div class="card-content">
-  {% raw report_html %}
+    {% raw report_html %}
   </div>
 </div>
 {% end %}


### PR DESCRIPTION
`%s` for datetime.strftime was not working due to compatibility. Its fixed by replacing `%s` with `%S`. 